### PR TITLE
Rechtschreibfehler in Warnung für das Pausieren

### DIFF
--- a/client/src/pages/PlayGame.js
+++ b/client/src/pages/PlayGame.js
@@ -145,7 +145,7 @@ function PlayGame(props) {
                 name = "Großhändler"
               break
             case 4:
-                name = "einzelhändler"
+                name = "Einzelhändler"
           }
           setGrundTimerStop("Countdown wurde von " + name + " pausiert")
         


### PR DESCRIPTION
einzelhändler war falsch geschrieben in pause meldung